### PR TITLE
Ensure argv[0] has the executable name.

### DIFF
--- a/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}/Main.cpp
+++ b/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}/Main.cpp
@@ -194,11 +194,12 @@ int Main(array<String^>^ args) {
     }
 
     printf("Configure argc/argv...\n");
-    wchar_t** argv = new wchar_t* [args->Length];
+    wchar_t** argv = new wchar_t* [args->Length + 1];
+    argv[0] = wstr(Application::ExecutablePath);
     for (int i = 0; i < args->Length; i++) {
-        argv[i] = wstr(args[i]);
+        argv[i + 1] = wstr(args[i]);
     }
-    status = PyConfig_SetArgv(&config, args->Length, argv);
+    status = PyConfig_SetArgv(&config, args->Length + 1, argv);
     if (PyStatus_Exception(status)) {
         crash_dialog("Unable to configure argc/argv: " + gcnew String(status.err_msg));
         PyConfig_Clear(&config);


### PR DESCRIPTION
For some reason, the Windows `Main(String [] args)` *doesn't* set `args[0]` to the name of the executable.

This PR modifies the argc/argv passed to Python to include this extra argument.

Refs beeware/briefcase#1078.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
