### PR TITLE
Uninitialize the threading model during app startup.

### DIFF
--- a/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}/CrashDialog.h
+++ b/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}/CrashDialog.h
@@ -23,7 +23,7 @@ namespace Briefcase {
 			this->Width = 540;
 			this->Height = 320;
 			this->Text = "Application has crashed";
-			this->Icon = this->Icon->ExtractAssociatedIcon(Application::ExecutablePath);
+			this->Icon = System::Drawing::Icon::ExtractAssociatedIcon(Application::ExecutablePath);
 
 			// The top-of-page introductory message
 			System::Windows::Forms::Label^ label = gcnew System::Windows::Forms::Label();

--- a/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.vcxproj
+++ b/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.vcxproj
@@ -53,7 +53,7 @@
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies />
+      <AdditionalDependencies>Ole32.lib</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
       <EntryPointSymbol>Main</EntryPointSymbol>
     </Link>
@@ -64,7 +64,7 @@
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies />
+      <AdditionalDependencies>Ole32.lib</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
       <EntryPointSymbol>Main</EntryPointSymbol>
     </Link>


### PR DESCRIPTION
During app startup, there appears to be an implicit call to set the Winforms threading model. This causes problems on Qt, which makes it's own call to set the threading model as part of app startup.

This adds a call to uninitialise the threading model at startup, ensuring that app-specific attempts to set the threading model 
won't cause a crash.

This doesn't appear to impact the operation of the Crash Dialog, or Toga's own Dialog behaviour (Toga sets STA mode during app startup). The sample program provided by beeware/briefcase#930 also appears to work.

Also cleans up some environment management code that was raising warnings about using "unsafe" versions of methods.

Huge thanks to @davidfokkema for the leg work leading to this PR.

This could/should be backported to 0.3.12; it will also require retagging the app-template repository.

Fixes beeware/briefcase#930.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
