### PR TITLE
Add support for cookiecutter>=2.2.0

### DIFF
--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -55,7 +55,7 @@
 
         <Directory Id="TARGETDIR" Name="SourceDir">
             <Directory Id="ProgramFiles64Folder">
-            {%- if cookiecutter.use_full_install_path == "True" %}
+            {%- if cookiecutter.use_full_install_path %}
                 <Directory Id="CompanyFolder" Name="{{ cookiecutter.author or 'Unknown Developer' }}">
                     <Directory Id="{{ cookiecutter.module_name }}_ROOTDIR" Name="{{ cookiecutter.formal_name }}" />
                 </Directory>


### PR DESCRIPTION
- Before version 2.2.0, `True`/`False` values were exposed as strings
- Now, they are the actual `True` and `False` symbols

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
