### PR TITLE
Add manifest file

### DIFF
--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/settings.manifest
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/settings.manifest
@@ -1,0 +1,23 @@
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" >
+
+  <!-- This is necessary to make Environment.OSversion return the actual OS version
+       in .NET versions older than 5:
+         * https://stackoverflow.com/a/75804647
+         * https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/5.0/environment-osversion-returns-correct-version
+  -->
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows Vista -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!-- Windows 10 / Windows 11 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
+
+</assembly>

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.vcxproj
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.vcxproj
@@ -95,6 +95,9 @@
   <ItemGroup>
     <Image Include="icon.ico" />
   </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="settings.manifest" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">


### PR DESCRIPTION
This allows Toga to determine the actual Windows version within `briefcase run`. It already works within `briefcase dev`, because then it's using the manifest of python.exe.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
