### PR TITLE
Add support for Console apps

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,6 +8,7 @@
     "author_email": "contact@example.com",
     "url": "http://example.com",
     "description": "Short description of app",
+    "console_app": false,
     "guid": "1409c8f5-c276-4cf3-a2fd-defcbdfef9a2",
     "install_scope": "",
     "use_full_install_path": true,

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,6 +3,7 @@
     "formal_name": "App Name",
     "app_name": "{{ cookiecutter.formal_name|lower|replace(' ', '-') }}",
     "module_name": "{{ cookiecutter.app_name|replace('-', '_') }}",
+    "bundle": "com.example",
     "version_triple": "0.0.1",
     "author": "Example Corporation",
     "author_email": "contact@example.com",
@@ -14,6 +15,7 @@
     "use_full_install_path": true,
     "python_version": "3.X.0",
     "_extensions": [
-        "briefcase.integrations.cookiecutter.PythonVersionExtension"
+        "briefcase.integrations.cookiecutter.PythonVersionExtension",
+        "briefcase.integrations.cookiecutter.UUIDExtension"
     ]
 }

--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -63,7 +63,14 @@
                 <Directory Id="{{ cookiecutter.module_name }}_ROOTDIR" Name="{{ cookiecutter.formal_name }}" />
             {%- endif %}
             </Directory>
-
+            {% if cookiecutter.console_app %}
+            <Component Id="SystemPathEnv" Guid="{{ ".".join(["system-path", cookiecutter.app_name] + cookiecutter.bundle.split(".")[::-1])|dns_uuid5 }}">
+                <Environment Id="AppendSystemPathEnvValue" Name="PATH" Action="set" Part="last" System="yes" Value="[{{ cookiecutter.module_name }}_ROOTDIR]" Permanent="no" />
+            </Component>
+            <Component Id="UserPathEnv" Guid="{{ ".".join(["user-path", cookiecutter.app_name] + cookiecutter.bundle.split(".")[::-1])|dns_uuid5 }}">
+                <Environment Id="AppendUserPathEnvValue" Name="PATH" Action="set" Part="last" System="no" Value="[{{ cookiecutter.module_name }}_ROOTDIR]" Permanent="no" />
+            </Component>
+            {% endif %}
             <Directory Id="ProgramMenuFolder">
                 <Directory Id="ProgramMenuSubfolder" Name="{{ cookiecutter.formal_name }}">
                     <Component
@@ -99,7 +106,16 @@
             <ComponentGroupRef Id="{{ cookiecutter.module_name }}_COMPONENTS" />
             <ComponentRef Id="ApplicationShortcuts"/>
         </Feature>
-
+        {% if cookiecutter.console_app %}
+        <Feature Id="SystemPathEnvFeature" Level="1">
+            <Condition Level="0">ALLUSERS=2 OR MSIINSTALLPERUSER=1</Condition>
+            <ComponentRef Id="SystemPathEnv"/>
+        </Feature>
+        <Feature Id="UserPathEnvFeature" Level="1">
+            <Condition Level="0">ALLUSERS=1</Condition>
+            <ComponentRef Id="UserPathEnv"/>
+        </Feature>
+        {% endif %}
         <WixVariable Id="WixUISupportPerUser" Value="1" Overridable="yes" />
         <WixVariable Id="WixUISupportPerMachine" Value="1" Overridable="yes" />
 

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.vcxproj
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.vcxproj
@@ -54,7 +54,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>Ole32.lib</AdditionalDependencies>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>{% if cookiecutter.console_app %}Console{% else %}Windows{% endif %}</SubSystem>
       <EntryPointSymbol>Main</EntryPointSymbol>
     </Link>
   </ItemDefinitionGroup>
@@ -65,7 +65,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>Ole32.lib</AdditionalDependencies>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>{% if cookiecutter.console_app %}Console{% else %}Windows{% endif %}</SubSystem>
       <EntryPointSymbol>Main</EntryPointSymbol>
     </Link>
   </ItemDefinitionGroup>
@@ -77,13 +77,13 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="CrashDialog.cpp" />
+{% if not cookiecutter.console_app %}    <ClCompile Include="CrashDialog.cpp" />{% endif %}
     <ClCompile Include="Main.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="CrashDialog.h">
+{% if not cookiecutter.console_app %}    <ClInclude Include="CrashDialog.h">
       <FileType>CppForm</FileType>
-    </ClInclude>
+    </ClInclude>{% endif %}
     <ClInclude Include="resource.h" />
   </ItemGroup>
   <ItemGroup>

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.vcxproj
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.vcxproj
@@ -46,7 +46,12 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <TargetName>{% if cookiecutter.console_app %}{{ cookiecutter.app_name }}{% else %}{{ cookiecutter.formal_name }}{% endif %}</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <TargetName>{% if cookiecutter.console_app %}{{ cookiecutter.app_name }}{% else %}{{ cookiecutter.formal_name }}{% endif %}</TargetName>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>


### PR DESCRIPTION
Adds support for console apps in Visual Studio projects.

This involves:
* Modifying the stub executable code to *not* perform the stdout/logger redirection used by GUI apps
* Link the stub binary against the Console system rather than the Windows subsystem
* Outputting `app-name.exe` rather than `Formal Name.exe`
* Modifying the MSI installer to add the installation path to the PATH environment (either the user's path or the system path, depending on the installation type selected).

Refs beeware/briefcase#1781
Refs beeware/briefcase#1850

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
