### PR TITLE
Correct the name of the .exe shortcut for console apps

### DIFF
--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -83,7 +83,7 @@
                                 Name="{{ cookiecutter.formal_name }}"
                                 Icon="ProductIcon"
                                 Description="{{ cookiecutter.description }}"
-                                Target="[{{ cookiecutter.module_name }}_ROOTDIR]{{ cookiecutter.formal_name }}.exe"
+                                Target="[{{ cookiecutter.module_name }}_ROOTDIR]{% if cookiecutter.console_app %}{{ cookiecutter.app_name }}{% else %}{{ cookiecutter.formal_name }}{% endif %}.exe"
                         />
                         <RegistryValue
                                 Root="HKCU"


### PR DESCRIPTION
The shortcut created for a console app was `Formal Name.exe`, when it should be `app-name.exe`.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
