### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
         # PySide6 produces very long paths that can't be packaged by WiX.
         # Disabling until the problem has been fixed. See beeware/briefcase#948
         # framework: [ "toga", "pyside6", "pygame", "console" ]

--- a/.github/workflows/update-binary.yml
+++ b/.github/workflows/update-binary.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
     steps:
     - name: Set Build Variables
       id: build-vars

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -3,10 +3,9 @@
 app_path = "x64/Release/app"
 app_packages_path = "x64/Release/app_packages"
 support_path = "x64/Release"
-{# Minor versions for 3.8, 3.9, and 3.10 cannot be bumped further -#}
-{# since Python is not hosting embeddable zipped versions of them -#}
+{# Minor versions for 3.9 and 3.10 cannot be bumped further since -#}
+{# Python is not hosting embeddable zipped versions of them -#}
 {{ {
-    "3.8": "support_revision = 10",
     "3.9": "support_revision = 13",
     "3.10": "support_revision = 11",
     "3.11": "support_revision = 9",


### PR DESCRIPTION
## Changes
- Drop Python 3.8 as Briefcase's `main` branch no longer supports it

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
