### PR TITLE
Allow for runpy returning non-integer results.

### DIFF
--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/Main.cpp
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/Main.cpp
@@ -248,17 +248,15 @@ int Main(array<String^>^ args) {
                     // SystemExit with error code
                     ret = (int) PyLong_AsLong(systemExit_code);
                 } else {
-                    // Convert exit code to a string. This is required by runpy._error
-                    ret = -11;
-                    info_log("---------------------------------------------------------------------------\n");
-                    info_log("Application quit abnormally!\n");
-
-                    // Display exit message in the crash dialog.
-                    crash_dialog(PyObject_CppString(systemExit_code));
+                    // SystemExit with a string for an error code.
+                    ret = 1;
                 }
             } else {
                 // Non-SystemExit; likely an uncaught exception
                 ret = -6;
+            }
+
+            if (ret != 0) {
                 info_log("---------------------------------------------------------------------------\n");
                 info_log("Application quit abnormally!\n");
 

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/Main.cpp
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/Main.cpp
@@ -25,6 +25,7 @@ wchar_t* wstr(String^);
 void setup_stdout(FileVersionInfo^);
 void crash_dialog(String^);
 String^ format_traceback(PyObject *type, PyObject *value, PyObject *traceback);
+String^ PyObject_CppString(PyObject *obj);
 
 int Main(array<String^>^ args) {
     int ret = 0;
@@ -243,9 +244,17 @@ int Main(array<String^>^ args) {
                 if (systemExit_code == NULL) {
                     debug_log("Could not determine exit code\n");
                     ret = -10;
-                }
-                else {
+                } else if (PyLong_Check(systemExit_code)) {
+                    // SystemExit with error code
                     ret = (int) PyLong_AsLong(systemExit_code);
+                } else {
+                    // Convert exit code to a string. This is required by runpy._error
+                    ret = -11;
+                    info_log("---------------------------------------------------------------------------\n");
+                    info_log("Application quit abnormally!\n");
+
+                    // Display exit message in the crash dialog.
+                    crash_dialog(PyObject_CppString(systemExit_code));
                 }
             } else {
                 // Non-SystemExit; likely an uncaught exception
@@ -364,6 +373,20 @@ void crash_dialog(System::String^ details) {
 {% endif %}
 
 /**
+ * Convert a Python object into a C++ String^. It's easiest to do this by
+ * using the Python API to encode to UTF-8, and then convert the UTF-8 byte
+ * string into UTF-16 using Windows APIs.
+ */
+String^ PyObject_CppString(PyObject* obj) {
+    Py_ssize_t size;
+    System::Text::UTF8Encoding^ utf8 = gcnew System::Text::UTF8Encoding;
+
+    const char* bytes = PyUnicode_AsUTF8AndSize(PyObject_Str(obj), &size);
+
+    return gcnew String(utf8->GetString((Byte *)bytes, (int) size));
+}
+
+/**
  * Convert a Python traceback object into a user-suitable string, stripping off
  * stack context that comes from this stub binary.
  *
@@ -410,13 +433,7 @@ String^ format_traceback(PyObject *type, PyObject *value, PyObject *traceback) {
     traceback_unicode = PyUnicode_Join(PyUnicode_FromString(""), traceback_list);
 
     // Convert the Python Unicode string into a UTF-16 Windows String.
-    // It's easiest to do this by using the Python API to encode to UTF-8,
-    // and then convert the UTF-8 byte string into UTF-16 using Windows APIs.
-    Py_ssize_t size;
-    const char* bytes = PyUnicode_AsUTF8AndSize(PyObject_Str(traceback_unicode), &size);
-
-    System::Text::UTF8Encoding^ utf8 = gcnew System::Text::UTF8Encoding;
-    traceback_str = gcnew String(utf8->GetString((Byte *)bytes, (int) size));
+    traceback_str = PyObject_CppString(traceback_unicode);
 
     // Clean up the traceback string, removing references to the installed app location
     traceback_str = traceback_str->Replace(Application::StartupPath, "");

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/Main.cpp
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/Main.cpp
@@ -239,7 +239,7 @@ int Main(array<String^>^ args) {
                 exit(-5);
             }
 
-            traceback_str = NULL;
+            traceback_str = nullptr;
             if (PyErr_GivenExceptionMatches(exc_value, PyExc_SystemExit)) {
                 systemExit_code = PyObject_GetAttrString(exc_value, "code");
                 if (systemExit_code == NULL) {
@@ -262,7 +262,7 @@ int Main(array<String^>^ args) {
                 traceback_str = format_traceback(exc_type, exc_value, exc_traceback);
             }
 
-            if (traceback_str != NULL) {
+            if (traceback_str != nullptr) {
                 // Display stack trace in the crash dialog.
                 crash_dialog(traceback_str);
             }

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/Main.cpp
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/Main.cpp
@@ -243,14 +243,19 @@ int Main(array<String^>^ args) {
             if (PyErr_GivenExceptionMatches(exc_value, PyExc_SystemExit)) {
                 systemExit_code = PyObject_GetAttrString(exc_value, "code");
                 if (systemExit_code == NULL) {
-                    debug_log("Could not determine exit code\n");
+                    traceback_str = "Could not determine exit code";
                     ret = -10;
+                } else if (systemExit_code == Py_None) {
+                    // SystemExit with a code of None; documented as a return
+                    // code of 0.
+                    ret = 0;
                 } else if (PyLong_Check(systemExit_code)) {
                     // SystemExit with error code
                     ret = (int) PyLong_AsLong(systemExit_code);
                 } else {
-                    // SystemExit with a string for an error code. Use the string as the
-                    // traceback, and use the documented SystemExit return value of 1.
+                    // Any other SystemExit value - convert to a string, and use
+                    // the string as the traceback, and use the documented
+                    // SystemExit return value of 1.
                     ret = 1;
                     traceback_str = PyObject_CppString(systemExit_code);
                 }

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/Main.cpp
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/Main.cpp
@@ -239,6 +239,7 @@ int Main(array<String^>^ args) {
                 exit(-5);
             }
 
+            traceback_str = NULL;
             if (PyErr_GivenExceptionMatches(exc_value, PyExc_SystemExit)) {
                 systemExit_code = PyObject_GetAttrString(exc_value, "code");
                 if (systemExit_code == NULL) {
@@ -248,20 +249,21 @@ int Main(array<String^>^ args) {
                     // SystemExit with error code
                     ret = (int) PyLong_AsLong(systemExit_code);
                 } else {
-                    // SystemExit with a string for an error code.
+                    // SystemExit with a string for an error code. Use the string as the
+                    // traceback, and use the documented SystemExit return value of 1.
                     ret = 1;
+                    traceback_str = PyObject_CppString(systemExit_code);
                 }
             } else {
                 // Non-SystemExit; likely an uncaught exception
-                ret = -6;
-            }
-
-            if (ret != 0) {
                 info_log("---------------------------------------------------------------------------\n");
                 info_log("Application quit abnormally!\n");
-
-                // Display stack trace in the crash dialog.
+                ret = -6;
                 traceback_str = format_traceback(exc_type, exc_value, exc_traceback);
+            }
+
+            if (traceback_str != NULL) {
+                // Display stack trace in the crash dialog.
                 crash_dialog(traceback_str);
             }
         }


### PR DESCRIPTION
Fixes #47.

Implements the same fix as beeware/briefcase-macOS-Xcode-template#65, with some additional refactoring of some common C++ String creation code.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
