### PR TITLE
Add file associations

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -13,6 +13,7 @@
     "guid": "1409c8f5-c276-4cf3-a2fd-defcbdfef9a2",
     "install_scope": "",
     "use_full_install_path": true,
+    "document_types": "",
     "python_version": "3.X.0",
     "_extensions": [
         "briefcase.integrations.cookiecutter.PythonVersionExtension",

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -14,6 +14,9 @@ support_path = "x64/Release"
 }.get(cookiecutter.python_version|py_tag, "") }}
 
 icon = "{{ cookiecutter.formal_name }}/icon.ico"
+{% for document_type_id, document_type in cookiecutter.document_types.items() -%}
+document_type_icon.{{ document_type_id }} = "{{ cookiecutter.app_name }}-{{ document_type_id }}.ico"
+{% endfor %}
 cleanup_paths = [
     "x64/Release/python*.exe",
 ]

--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -98,6 +98,21 @@
             </Directory>
         </Directory>
 
+        {% if cookiecutter.document_types -%}
+        <SetProperty Id='FileAssociationProperty' Value="[{{ cookiecutter.module_name }}_ROOTDIR]{{ cookiecutter.formal_name }}.exe" After="CostFinalize"/>
+
+        {% for document_type_id, document_type in cookiecutter.document_types|dictsort -%}
+        <Component Id="FileAssociation.{{ document_type_id }}" Directory="{{ cookiecutter.module_name }}_ROOTDIR" Guid="*">
+            <File Id="ProductIcon.{{ document_type_id }}" Source="{{ cookiecutter.app_name }}-{{ document_type_id }}.ico" />
+            <ProgId Id="MyApp.{{ document_type_id }}" Description="{{ document_type.description }}" Icon="ProductIcon.{{ document_type_id }}">
+                <Extension Id="{{ document_type.extension }}" ContentType="{% if document_type.get('mime_type') %}{{ document_type.mime_type }}{% else %}application/x-{{ cookiecutter.app_name }}-{{ document_type_id }}{% endif %}">
+                    <Verb Id="open" Command="Open" TargetProperty="FileAssociationProperty" Argument='"%1"' />
+                </Extension>
+            </ProgId>
+        </Component>
+        {%- endfor %}
+        {%- endif %}
+
         <InstallExecuteSequence>
             <RemoveExistingProducts After="InstallValidate"/>
         </InstallExecuteSequence>
@@ -105,6 +120,9 @@
         <Feature Id="DefaultFeature" Level="1">
             <ComponentGroupRef Id="{{ cookiecutter.module_name }}_COMPONENTS" />
             <ComponentRef Id="ApplicationShortcuts"/>
+            {%- for document_type_id in cookiecutter.document_types.keys()|sort %}
+            <ComponentRef Id="FileAssociation.{{ document_type_id }}"/>
+            {%- endfor %}
         </Feature>
         {% if cookiecutter.console_app %}
         <Feature Id="SystemPathEnvFeature" Level="1">


### PR DESCRIPTION
Copied changes from beeware/briefcase-windows-app-template#62

This PR adds file associations to Windows apps. The support in briefcase.toml is already there and the feature is documented. It wasn't yet implemented for Windows, however.

Refs beeware/briefcase#1706 (corrects the problem for Windows).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
