### PR TITLE
[2103] fix: Adds author xml escaping

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,6 +6,7 @@
     "bundle": "com.example",
     "version_triple": "0.0.1",
     "author": "Example Corporation",
+    "safe_author": "{{ cookiecutter.author|xml_escape }}",
     "author_email": "contact@example.com",
     "url": "http://example.com",
     "description": "Short description of app",
@@ -17,6 +18,7 @@
     "python_version": "3.X.0",
     "_extensions": [
         "briefcase.integrations.cookiecutter.PythonVersionExtension",
-        "briefcase.integrations.cookiecutter.UUIDExtension"
+        "briefcase.integrations.cookiecutter.UUIDExtension",
+        "briefcase.integrations.cookiecutter.XMLExtension"
     ]
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,7 +6,6 @@
     "bundle": "com.example",
     "version_triple": "0.0.1",
     "author": "Example Corporation",
-    "safe_author": "{{ cookiecutter.author|xml_escape }}",
     "author_email": "contact@example.com",
     "url": "http://example.com",
     "description": "Short description of app",

--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -10,7 +10,7 @@
 
         <Media Id="1" Cabinet="product.cab" EmbedCab="yes" />
 
-        <Icon Id="ProductIcon" SourceFile="{{ cookiecutter.formal_name }}/icon.ico" />
+        <Icon Id="ProductIcon" SourceFile="{{ cookiecutter.formal_name|xml_escape }}/icon.ico" />
 
         <!-- Add/Remove Programs settings -->
         <Property Id="ARPPRODUCTICON" Value="ProductIcon" />
@@ -42,7 +42,7 @@
             {%- endif %}
         </StandardDirectory>
 
-        <ComponentGroup Id="{{ cookiecutter.module_name }}_COMPONENTS">
+        <ComponentGroup Id="{{ cookiecutter.module_name|xml_escape }}_COMPONENTS">
             <!-- "\\?\" enables long paths (https://github.com/wixtoolset/issues/issues/9115). -->
             <Files
                 Directory="INSTALLFOLDER"
@@ -81,14 +81,14 @@
             Id="FileAssociation.{{ document_type_id }}"
             Directory="INSTALLFOLDER">
             <File
-                Id="ProductIcon.{{ document_type_id }}"
-                Source="{{ cookiecutter.app_name }}-{{ document_type_id }}.ico" />
+                Id="ProductIcon.{{ document_type_id|xml_escape }}"
+                Source="{{ cookiecutter.app_name }}-{{ document_type_id|xml_escape }}.ico" />
             <ProgId
-                Id="{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.{{ document_type_id }}"
+                Id="{{ cookiecutter.bundle|xml_escape }}.{{ cookiecutter.app_name|xml_escape }}.{{ document_type_id|xml_escape }}"
                 Description="{{ document_type.description|xml_escape }}"
                 Icon="ProductIcon.{{ document_type_id }}">
                 <Extension
-                    Id="{{ document_type.extension }}"
+                    Id="{{ document_type.extension|xml_escape }}"
                     ContentType="{% if document_type.get('mime_type') %}{{ document_type.mime_type|xml_escape }}{% else %}application/x-{{ cookiecutter.app_name }}-{{ document_type_id }}{% endif %}">
                     <Verb
                         Id="open"
@@ -102,7 +102,7 @@
         {%- endif %}
 
         <Feature Id="DefaultFeature">
-            <ComponentGroupRef Id="{{ cookiecutter.module_name }}_COMPONENTS" />
+            <ComponentGroupRef Id="{{ cookiecutter.module_name|xml_escape }}_COMPONENTS" />
             <ComponentRef Id="ApplicationShortcuts" />
             {%- for document_type_id in cookiecutter.document_types.keys()|sort %}
             <ComponentRef Id="FileAssociation.{{ document_type_id }}" />

--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -18,7 +18,7 @@
         <Property Id="ARPURLINFOABOUT" Value="{{ cookiecutter.url|xml_escape }}" />
         {% endif -%}
         {% if cookiecutter.author_email -%}
-        <Property Id="ARPCONTACT" Value="{{ cookiecutter.author_email|xml_escape }}" />
+        <Property Id="ARPCONTACT" Value="{{ cookiecutter.author_email }}" />
         {% endif -%}
         <Property Id="ARPNOREPAIR" Value="1" />
         <Property Id="ARPNOMODIFY" Value="1" />
@@ -42,7 +42,7 @@
             {%- endif %}
         </StandardDirectory>
 
-        <ComponentGroup Id="{{ cookiecutter.module_name|xml_escape }}_COMPONENTS">
+        <ComponentGroup Id="{{ cookiecutter.module_name }}_COMPONENTS">
             <!-- "\\?\" enables long paths (https://github.com/wixtoolset/issues/issues/9115). -->
             <Files
                 Directory="INSTALLFOLDER"
@@ -84,11 +84,11 @@
                 Id="ProductIcon.{{ document_type_id|xml_escape }}"
                 Source="{{ cookiecutter.app_name }}-{{ document_type_id|xml_escape }}.ico" />
             <ProgId
-                Id="{{ cookiecutter.bundle|xml_escape }}.{{ cookiecutter.app_name|xml_escape }}.{{ document_type_id|xml_escape }}"
+                Id="{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.{{ document_type_id|xml_escape }}"
                 Description="{{ document_type.description|xml_escape }}"
                 Icon="ProductIcon.{{ document_type_id }}">
                 <Extension
-                    Id="{{ document_type.extension|xml_escape }}"
+                    Id="{{ document_type.extension }}"
                     ContentType="{% if document_type.get('mime_type') %}{{ document_type.mime_type|xml_escape }}{% else %}application/x-{{ cookiecutter.app_name }}-{{ document_type_id }}{% endif %}">
                     <Verb
                         Id="open"
@@ -102,7 +102,7 @@
         {%- endif %}
 
         <Feature Id="DefaultFeature">
-            <ComponentGroupRef Id="{{ cookiecutter.module_name|xml_escape }}_COMPONENTS" />
+            <ComponentGroupRef Id="{{ cookiecutter.module_name }}_COMPONENTS" />
             <ComponentRef Id="ApplicationShortcuts" />
             {%- for document_type_id in cookiecutter.document_types.keys()|sort %}
             <ComponentRef Id="FileAssociation.{{ document_type_id }}" />

--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -1,9 +1,9 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
     <Package
         UpgradeCode="{{ cookiecutter.guid }}"
-        Name="{{ cookiecutter.formal_name }}"
+        Name="{{ cookiecutter.formal_name|xml_escape }}"
         Version="{{ cookiecutter.version_triple }}"
-        Manufacturer="{{ cookiecutter.author or 'Anonymous' }}"
+        Manufacturer="{{ (cookiecutter.author or 'Anonymous')|xml_escape }}"
         Language="1033"
         Scope="{{ 'perUserOrMachine' if 'User' in cookiecutter.install_scope else 'perMachine' }}">
         <!-- See scope comments below -->
@@ -15,10 +15,10 @@
         <!-- Add/Remove Programs settings -->
         <Property Id="ARPPRODUCTICON" Value="ProductIcon" />
         {% if cookiecutter.url -%}
-        <Property Id="ARPURLINFOABOUT" Value="{{ cookiecutter.url }}" />
+        <Property Id="ARPURLINFOABOUT" Value="{{ cookiecutter.url|xml_escape }}" />
         {% endif -%}
         {% if cookiecutter.author_email -%}
-        <Property Id="ARPCONTACT" Value="{{ cookiecutter.author_email }}" />
+        <Property Id="ARPCONTACT" Value="{{ cookiecutter.author_email|xml_escape }}" />
         {% endif -%}
         <Property Id="ARPNOREPAIR" Value="1" />
         <Property Id="ARPNOMODIFY" Value="1" />
@@ -34,9 +34,9 @@
         depending on the values of the ALLUSERS and MSIINSTALLPERUSER properties. -->
         <StandardDirectory Id="ProgramFiles64Folder">
             {%- if cookiecutter.use_full_install_path %}
-            <Directory Name="{{ cookiecutter.author or 'Unknown Developer' }}">
+            <Directory Name="{{ (cookiecutter.author or 'Unknown Developer')|xml_escape }}">
             {%- endif %}
-            <Directory Id="INSTALLFOLDER" Name="{{ cookiecutter.formal_name }}" />
+            <Directory Id="INSTALLFOLDER" Name="{{ cookiecutter.formal_name|xml_escape }}" />
             {%- if cookiecutter.use_full_install_path %}
             </Directory>
             {%- endif %}
@@ -46,21 +46,21 @@
             <!-- "\\?\" enables long paths (https://github.com/wixtoolset/issues/issues/9115). -->
             <Files
                 Directory="INSTALLFOLDER"
-                Include="\\?\{{ cookiecutter.package_path }}\**" />
+                Include="\\?\{{ cookiecutter.package_path|xml_escape }}\**" />
         </ComponentGroup>
 
         <StandardDirectory Id="ProgramMenuFolder">
-            <Directory Id="ProgramMenuSubfolder" Name="{{ cookiecutter.formal_name }}">
+            <Directory Id="ProgramMenuSubfolder" Name="{{ cookiecutter.formal_name|xml_escape }}">
                 <Component Id="ApplicationShortcuts">
                     <Shortcut
                         Id="ApplicationShortcut1"
-                        Name="{{ cookiecutter.formal_name }}"
+                        Name="{{ cookiecutter.formal_name|xml_escape }}"
                         Icon="ProductIcon"
-                        Description="{{ cookiecutter.description }}"
+                        Description="{{ cookiecutter.description|xml_escape }}"
                         Target="[INSTALLFOLDER]{{ cookiecutter.binary_path }}" />
                     <RegistryValue
                         Root="HKMU"
-                        Key="Software\{{ cookiecutter.author or 'Unknown Developer' }}\{{ cookiecutter.formal_name }}"
+                        Key="Software\{{ (cookiecutter.author or 'Unknown Developer')|xml_escape }}\{{ cookiecutter.formal_name|xml_escape }}"
                         Name="installed"
                         Type="integer"
                         Value="1"
@@ -85,11 +85,11 @@
                 Source="{{ cookiecutter.app_name }}-{{ document_type_id }}.ico" />
             <ProgId
                 Id="{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.{{ document_type_id }}"
-                Description="{{ document_type.description }}"
+                Description="{{ document_type.description|xml_escape }}"
                 Icon="ProductIcon.{{ document_type_id }}">
                 <Extension
                     Id="{{ document_type.extension }}"
-                    ContentType="{% if document_type.get('mime_type') %}{{ document_type.mime_type }}{% else %}application/x-{{ cookiecutter.app_name }}-{{ document_type_id }}{% endif %}">
+                    ContentType="{% if document_type.get('mime_type') %}{{ document_type.mime_type|xml_escape }}{% else %}application/x-{{ cookiecutter.app_name }}-{{ document_type_id }}{% endif %}">
                     <Verb
                         Id="open"
                         Command="Open"

--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -7,7 +7,7 @@
             UpgradeCode="$(var.ProductUpgradeCode)"
             Name="{{ cookiecutter.formal_name }}"
             Version="$(var.ProductVersion)"
-            Manufacturer="{{ cookiecutter.author or 'Anonymous' }}"
+            Manufacturer="{{ cookiecutter.safe_author or 'Anonymous' }}"
             Language="1033"
             Codepage="utf-8">
         <Package
@@ -56,7 +56,7 @@
         <Directory Id="TARGETDIR" Name="SourceDir">
             <Directory Id="ProgramFiles64Folder">
             {%- if cookiecutter.use_full_install_path %}
-                <Directory Id="CompanyFolder" Name="{{ cookiecutter.author or 'Unknown Developer' }}">
+                <Directory Id="CompanyFolder" Name="{{ cookiecutter.safe_author or 'Unknown Developer' }}">
                     <Directory Id="{{ cookiecutter.module_name }}_ROOTDIR" Name="{{ cookiecutter.formal_name }}" />
                 </Directory>
             {%- else %}
@@ -87,7 +87,7 @@
                         />
                         <RegistryValue
                                 Root="HKCU"
-                                Key="Software\{{ cookiecutter.author or 'Unknown Developer' }}\{{ cookiecutter.formal_name }}"
+                                Key="Software\{{ cookiecutter.safe_author or 'Unknown Developer' }}\{{ cookiecutter.formal_name }}"
                                 Name="installed"
                                 Type="integer"
                                 Value="1"


### PR DESCRIPTION
Adds XMLEscape extension to author name usage in {{ cookiecutter.app_name }}.xws

Partially fixes [beeware/briefcase#2103](https://github.com/beeware/briefcase/issues/2103)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
