### PR TITLE
Add handling for customized external binaries.

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -13,6 +13,7 @@
     "guid": "1409c8f5-c276-4cf3-a2fd-defcbdfef9a2",
     "install_scope": "",
     "use_full_install_path": true,
+    "binary_path": "{{ cookiecutter.formal_name }}.exe",
     "document_types": "",
     "python_version": "3.X.0",
     "_extensions": [

--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -83,7 +83,7 @@
                                 Name="{{ cookiecutter.formal_name }}"
                                 Icon="ProductIcon"
                                 Description="{{ cookiecutter.description }}"
-                                Target="[{{ cookiecutter.module_name }}_ROOTDIR]{% if cookiecutter.console_app %}{{ cookiecutter.app_name }}{% else %}{{ cookiecutter.formal_name }}{% endif %}.exe"
+                                Target="[{{ cookiecutter.module_name }}_ROOTDIR]{{ cookiecutter.binary_path }}"
                         />
                         <RegistryValue
                                 Root="HKCU"


### PR DESCRIPTION
Provide the extension point allowing the Start menu item installed by Briefcase to point at an arbitrary path in the packaged bundle.

Refs beeware/briefcase#2333
Refs beeware/briefcase-windows-app-template#66

briefcase-repo: https://github.com/freakboy3742/briefcase.git
briefcase-ref: non-briefcase-package

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
