### PR TITLE
Restore Pyside6 tests, as Wix 5 now supports long paths.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,4 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
-        # PySide6 produces very long paths that can't be packaged by WiX.
-        # Disabling until the problem has been fixed. See beeware/briefcase#948
-        # framework: [ "toga", "pyside6", "pygame", "console" ]
-        framework: [ "toga", "pygame", "console" ]
+        framework: [ "toga", "pyside6", "pygame", "console" ]


### PR DESCRIPTION
beeware/briefcase#2355 upgrades the WiX version to WiX 5, which should no longer have the the path length restriction - so we can restore pyside6 tests to the Windows tests.

Fixes beeware/briefcase#948.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
