### PR TITLE
Drop Python 3.9, add 3.14.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,5 +38,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
         framework: [ "toga", "pyside6", "pygame", "console" ]
+        # Pygame and PySide6 haven't published 3.14 wheels yet.
+        exclude:
+          - python-version: "3.14"
+            framework: pyside6
+          - python-version: "3.14"
+            framework: pygame

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,11 @@ jobs:
         python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
         framework: [ "toga", "pyside6", "pygame", "console" ]
         # Pygame and PySide6 haven't published 3.14 wheels yet.
+        # Toga is waiting on a release of Python.net for 3.14
         exclude:
           - python-version: "3.14"
             framework: pyside6
           - python-version: "3.14"
             framework: pygame
+          - python-version: "3.14"
+            framework: toga

--- a/.github/workflows/update-binary.yml
+++ b/.github/workflows/update-binary.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
     steps:
     - name: Set Build Variables
       id: build-vars

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -13,7 +13,7 @@ support_path = "x64/Release"
     "3.11": "support_revision = 9",
     "3.12": "support_revision = 9",
     "3.13": "support_revision = 6",
-    "3.14": "support_revision = 0rc1",
+    "3.14": "support_revision = '0rc1'",
 }.get(cookiecutter.python_version|py_tag, "") }}
 
 icon = "{{ cookiecutter.formal_name }}/icon.ico"

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -6,14 +6,14 @@ target_version = "0.3.24"
 app_path = "x64/Release/app"
 app_packages_path = "x64/Release/app_packages"
 support_path = "x64/Release"
-{# Minor versions for 3.9, 3.10, and 3.11 cannot be bumped further -#}
+{# Minor versions for 3.10, 3.11, and 3.12 cannot be bumped further -#}
 {# since Python is not hosting embeddable zipped versions of them -#}
 {{ {
-    "3.9": "support_revision = 13",
     "3.10": "support_revision = 11",
     "3.11": "support_revision = 9",
     "3.12": "support_revision = 9",
-    "3.13": "support_revision = 3",
+    "3.13": "support_revision = 6",
+    "3.14": "support_revision = 0rc1",
 }.get(cookiecutter.python_version|py_tag, "") }}
 
 icon = "{{ cookiecutter.formal_name }}/icon.ico"

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/Main.cpp
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/Main.cpp
@@ -72,8 +72,13 @@ int Main(array<String^>^ args) {
     debug_log("PreInitializing Python runtime...\n");
     PyPreConfig pre_config;
     PyPreConfig_InitPythonConfig(&pre_config);
+    // Enforce UTF-8 encoding for stderr, stdout, file-system encoding and locale.
+    // See https://docs.python.org/3/library/os.html#python-utf-8-mode.
     pre_config.utf8_mode = 1;
+    // Ensure the locale is set (isolated interpreters won't by default)
+    pre_config.configure_locale = 1;
     pre_config.isolated = 1;
+
     status = Py_PreInitialize(&pre_config);
     if (PyStatus_Exception(status)) {
         crash_dialog("Unable to pre-initialize Python runtime.");

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/packages.config
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="python" version="{{ cookiecutter.python_version }}" targetFramework="native" />
+  <package id="python" version="{{ cookiecutter.python_version|nuget_version }}" targetFramework="native" />
 </packages>

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.vcxproj
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.vcxproj
@@ -109,6 +109,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\python.{{ cookiecutter.python_version }}\build\native\python.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\python.{{ cookiecutter.python_version }}\build\native\python.props'))" />
+    <Error Condition="!Exists('..\packages\python.{{ cookiecutter.python_version|nuget_version }}\build\native\python.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\python.{{ cookiecutter.python_version|nuget_version }}\build\native\python.props'))" />
   </Target>
 </Project>

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.vcxproj
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\python.{{ cookiecutter.python_version }}\build\native\python.props" Condition="Exists('..\packages\python.{{ cookiecutter.python_version }}\build\native\python.props')" />
+  <Import Project="..\packages\python.{{ cookiecutter.python_version|nuget_version }}\build\native\python.props" Condition="Exists('..\packages\python.{{ cookiecutter.python_version|nuget_version }}\build\native\python.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>


### PR DESCRIPTION
Python 3.9 is EOL; 3.14 is now available.

Also includes the fix for locale initialization (see beeware/briefcase-iOS-Xcode-template#57).

This will require re-tagging of the binaries to generate the first 3.14 binary.

Needs an update when 3.14.0 final is available.

~~Requires beeware/briefcase#2432 for the 3.14 tests to pass.~~
Requires beeware/briefcase#2433 for the 3.14 tests to pass.

briefcase-repo: https://github.com/freakboy3742/briefcase
briefcase-ref: nuget-filter

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
