### PR TITLE
Allow Python prereleases in update-binary workflow

### DIFF
--- a/.github/workflows/update-binary.yml
+++ b/.github/workflows/update-binary.yml
@@ -1,8 +1,13 @@
 name: Update binary
 on:
+  pull_request:
   push:
     tags:
     - 'b*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 defaults:
   run:
@@ -34,6 +39,7 @@ jobs:
       uses: actions/setup-python@v5.6.0
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
 
     - name: Install Dependencies
       run: |
@@ -58,6 +64,7 @@ jobs:
         ls -1 *.zip
 
     - name: Upload Release Asset to S3
+      if: github.event_name == 'push'
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
My [first attempt](https://github.com/beeware/briefcase-windows-VisualStudio-template/actions/runs/16859814338) at tagging release `b10` failed because the workflow didn't allow prereleases for Python 3.14. This PR fixes that, and also enables most of the workflow in pull requests so issues like this will be discovered earlier in future.

I've deleted the `b10` tag, so you can create it again after this PR is merged.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
