### PR TITLE
Ttruncate description if larger than 256 chars

### DIFF
--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -56,7 +56,7 @@
                         Id="ApplicationShortcut1"
                         Name="{{ cookiecutter.formal_name }}"
                         Icon="ProductIcon"
-                        Description="{{ cookiecutter.description }}"
+                        Description="{{ cookiecutter.description | truncate(256, False) }}"
                         Target="[INSTALLFOLDER]{{ cookiecutter.binary_path }}" />
                     <RegistryValue
                         Root="HKMU"


### PR DESCRIPTION
Change the template to prevent descriptions longer than 256 chars 

Fix for [briefcase truncated icon issue](https://github.com/beeware/briefcase/issues/2465)

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
