### PR TITLE
Use windows-2022 runner for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
         framework: [ "toga", "pyside6", "pygame", "console" ]
-        runs-on: ["windows-latest", "windows-11-arm"]
+        runs-on: ["windows-2022", "windows-11-arm"]
         exclude:
           # Github Actions doesn't provide Windows/ARM64 builds for Python 3.10
           - python-version: "3.10"

--- a/.github/workflows/update-binary.yml
+++ b/.github/workflows/update-binary.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         python-version: [ "3.11", "3.12", "3.13", "3.14" ]
         config:
-          - runner: windows-latest
+          - runner: windows-2022
             vscode_arch: x64
             arch: amd64
           - runner: windows-11-arm
@@ -30,7 +30,7 @@ jobs:
           # GitHub doesn't provide ARM64 binaries for Python 3.10
           - python-version: "3.10"
             config:
-              runner: windows-latest
+              runner: windows-2022
               vscode_arch: x64
               arch: amd64
 


### PR DESCRIPTION
GitHub will migrate the `windows-latest` runner to Visual Studio 2026 soon: https://github.blog/changelog/2026-05-14-github-actions-upcoming-image-migrations/

Continuing to use `windows-latest` will require the template to upgrade to the v145 version of VS build tools, but the ARM runner is unlikely to be upgraded at the same time despite being owned by GitHub now (they explicitly state no breaking changes will be introduced at the moment).

Refs #96.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
