### PR TITLE
Add extra default paths to PYTHONPATH.

### DIFF
--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/Main.cpp
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/Main.cpp
@@ -145,8 +145,28 @@ int Main(array<String^>^ args) {
         Py_ExitStatusException(status);
     }
 
-    // The unpacked form of the stdlib
+    // The unpacked form of the stdlib in the root of the app (Embedded CPython style)
     path = python_home;
+    debug_log("- %S\n", wstr(path));
+    status = PyWideStringList_Append(&config.module_search_paths, wstr(path));
+    if (PyStatus_Exception(status)) {
+        crash_dialog("Unable to set unpacked form of stdlib path: " + gcnew String(status.err_msg));
+        PyConfig_Clear(&config);
+        Py_ExitStatusException(status);
+    }
+
+    // The unpacked form of the stdlib in a Lib folder (Conda style)
+    path = python_home + "\\Lib";
+    debug_log("- %S\n", wstr(path));
+    status = PyWideStringList_Append(&config.module_search_paths, wstr(path));
+    if (PyStatus_Exception(status)) {
+        crash_dialog("Unable to set unpacked form of stdlib path: " + gcnew String(status.err_msg));
+        PyConfig_Clear(&config);
+        Py_ExitStatusException(status);
+    }
+
+    // Standard library DLLs in a standalone folder (Conda style)
+    path = python_home + "\\DLLs";
     debug_log("- %S\n", wstr(path));
     status = PyWideStringList_Append(&config.module_search_paths, wstr(path));
     if (PyStatus_Exception(status)) {

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/Main.cpp
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}/Main.cpp
@@ -160,7 +160,7 @@ int Main(array<String^>^ args) {
     debug_log("- %S\n", wstr(path));
     status = PyWideStringList_Append(&config.module_search_paths, wstr(path));
     if (PyStatus_Exception(status)) {
-        crash_dialog("Unable to set unpacked form of stdlib path: " + gcnew String(status.err_msg));
+        crash_dialog("Unable to set Lib form of stdlib path: " + gcnew String(status.err_msg));
         PyConfig_Clear(&config);
         Py_ExitStatusException(status);
     }
@@ -170,7 +170,7 @@ int Main(array<String^>^ args) {
     debug_log("- %S\n", wstr(path));
     status = PyWideStringList_Append(&config.module_search_paths, wstr(path));
     if (PyStatus_Exception(status)) {
-        crash_dialog("Unable to set unpacked form of stdlib path: " + gcnew String(status.err_msg));
+        crash_dialog("Unable to add DLLs folder to stdlib path: " + gcnew String(status.err_msg));
         PyConfig_Clear(&config);
         Py_ExitStatusException(status);
     }


### PR DESCRIPTION
A Conda-based Windows app will put Python code in different locations:

* The standard library is contained in the `Lib` subfolder. 
* `.pyd` binaries from the standard library are in the `DLLs` subfolder.

As there's no real cost to adding extra paths to the PYTHONPATH, this adds the Conda-compatible paths to the stub binary. allowing the same stub to be used on both Conda and pip-based environments.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
