### PR TITLE
Limit MSI shortcut descriptions to 256 characters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - name: Run template tests
+        run: python -m unittest discover -s tests
       - run: |
           target_windows_build=$(grep -oP 'target_windows_build = \K\d+' "{{ cookiecutter.format }}/briefcase.toml")
           min_os_version=$(grep -oP '"min_os_version": "\K\d+(?=")' "cookiecutter.json")

--- a/tests/test_wxs_template.py
+++ b/tests/test_wxs_template.py
@@ -1,0 +1,33 @@
+import re
+import unittest
+from pathlib import Path
+
+
+TEMPLATE = Path("{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs")
+
+
+class ShortcutDescriptionTests(unittest.TestCase):
+    def test_shortcut_description_is_strictly_limited(self):
+        """Shortcut descriptions must fit within WiX's 256-character limit."""
+        wxs_template = TEMPLATE.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "{%- set description = cookiecutter.description[:256] %}",
+            wxs_template,
+        )
+
+    def test_shortcuts_use_limited_description(self):
+        """Start menu and desktop shortcuts use the limited description."""
+        wxs_template = TEMPLATE.read_text(encoding="utf-8")
+
+        shortcut_descriptions = re.findall(
+            r"<Shortcut\b(?:(?!</?Shortcut\b).)*?Description=\"([^\"]+)\"",
+            wxs_template,
+            flags=re.DOTALL,
+        )
+
+        self.assertEqual(shortcut_descriptions, ["{{ description }}"] * 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -1,6 +1,6 @@
 {%- set formal_name = cookiecutter.formal_name|xml_escape %}
 {%- set author = (cookiecutter.author or 'Unknown Developer')|xml_escape %}
-{%- set description = cookiecutter.description | truncate(256, False) %}
+{%- set description = cookiecutter.description[:256] %}
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
      xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui"
      xmlns:netfx="http://wixtoolset.org/schemas/v4/wxs/netfx"


### PR DESCRIPTION
Refs beeware/briefcase#2864.

WiX shortcut descriptions have a 256-character limit. The template previously used Jinja's `truncate(256, False)`, but Jinja's default leeway means descriptions slightly over the limit, such as 260 characters, may not be truncated at all.

This changes the shortcut description value to use an explicit 256-character slice, ensuring MSI shortcut descriptions always stay within the WiX limit.

Tests added:
- Verify the template defines a strict 256-character description limit.
- Verify the MSI shortcut uses the limited description value.

Local verification:
- `python -m unittest discover -s tests`
- `git diff --check`
- `pre-commit run --all-files`

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool

Assisted-by: OpenAI Codex