### PR TITLE
Add 7-day cooldown to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       # Check for updates on the first Sunday of every month, 8PM UTC
       interval: "cron"
       cronjob: "0 20 * * sun#1"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pre-commit"
     directory: "/"
@@ -13,3 +15,5 @@ updates:
       # Check for updates on the first Sunday of every month, 8PM UTC
       interval: "cron"
       cronjob: "0 20 * * sun#1"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary

Add a 7-day cooldown to Dependabot updates for both `github-actions` and `pre-commit` in `.github/dependabot.yml`.

This aligns the repository's Dependabot configuration with the referenced BeeWare configuration and reduces the frequency of update PRs.

Fixes #108

## PR Checklist

- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the CONTRIBUTING.md file
- [x] This PR was generated or assisted using an AI tool
